### PR TITLE
Added command line options --addCustomOutputLUT and --addCustomRole t…

### DIFF
--- a/aces_1.0.2/python/aces_ocio/generate_config.py
+++ b/aces_1.0.2/python/aces_ocio/generate_config.py
@@ -44,6 +44,7 @@ __all__ = ['ACES_OCIO_CTL_DIRECTORY_ENVIRON',
            'add_colorspace_aliases',
            'add_look',
            'add_looks_to_views',
+           'add_custom_output',
            'create_config',
            'create_config_data',
            'write_config',
@@ -527,12 +528,108 @@ def add_looks_to_views(looks,
                     colorspace_c)
                 config_data['displays'][display] = view_list
 
+def add_custom_output(config,
+                      custom_output,
+                      custom_lut_dir,
+                      reference_colorspace,
+                      config_data,
+                      alias_colorspaces,
+                      prefix=False,
+                      make_default=True,):
+    """
+    Adds given custom output transform to the *OCIO* config.
+
+    Parameters
+    ----------
+    config : Config
+        *OCIO* configuration.
+    custom_output : array_like
+        Custom Output Transform description: {'name', 'colorspace', 'lut', 'cccid'}
+    custom_lut_dir : str or unicode
+        Directory to copy the look lut into.
+    reference_colorspace_name : str or unicode
+        Reference name.
+    config_data : dict
+        Colorspaces and transforms converting between those colorspaces and
+        the reference colorspace, *ACES*.
+    alias_colorspaces: list of str
+        A list of colorspace alias triples (source colorspace, name, alias names)
+    prefix : boolean
+        Whether to prefix the family name in front of the colorspae name
+    make_default : boolean
+        Control over whether or not this output becomes the default
+
+    Returns
+    -------
+    bool
+        Definition success.
+    """
+
+    family='Output'
+    reference_colorspace_name = reference_colorspace.name
+
+    (custom_output_name, custom_output_working_colorspace_name, 
+        custom_output_lut, custom_output_cccid) = unpack_default(custom_output, 4)
+
+    print('Adding custom output %s - \n\t%s' % (custom_output_name, '\n\t'.join(custom_output)))
+
+    # Copy *custom output LUT* if `custom_lut_dir` is provided.
+    if custom_lut_dir:
+        if '$' not in custom_output_lut:
+            print('Getting ready to copy look lut : %s' % custom_output_lut)
+            shutil.copy2(custom_output_lut, custom_lut_dir)
+            custom_output_lut = os.path.split(custom_output_lut)[1]
+        else:
+            print('Skipping LUT copy because path contains a context variable')
+
+    # Add a colorspace for the custom output LUT
+    print('Adding colorspace for custom output to config')
+    custom_output_colorspace = ColorSpace(custom_output_name,
+                              description='The %s colorspace' % custom_output_name,
+                              family=family)
+
+    print('\tGenerating From-Reference transforms')
+    transforms = []
+
+    # Convert to colorspace LUT expects
+    transforms.append({'type': 'colorspace',
+      'src': reference_colorspace_name,
+      'dst': custom_output_working_colorspace_name,
+      'direction': 'forward'})
+
+    # Apply LUT
+    lut_keys = {'type': 'lutFile',
+                'path': custom_output_lut,
+                'direction': 'forward'}
+    if custom_output_cccid:
+        lut_keys['cccid'] = custom_output_cccid
+    transforms.append(lut_keys)
+
+    # Create OCIO transforms
+    custom_output_colorspace.from_reference_transforms = transforms
+
+    config_data['colorSpaces'].append(custom_output_colorspace)
+
+    print( "Adding Display for custom output %s" % (custom_output_name))
+    view_list = {'Output Transform':custom_output_colorspace}
+    config_data['displays'][custom_output_name] = view_list
+
+    print('Creating alias colorspace')
+    custom_output_alias_name = 'out_%s' % compact(custom_output_name)
+    custom_output_colorspace.aliases = [custom_output_alias_name]
+
+    if make_default:
+        print( "Making %s the default Display" % custom_output_name)
+        config_data['defaultDisplay'] = custom_output_name
+
+    print('')
 
 def create_config(config_data,
                   aliases=False,
                   prefix=False,
                   multiple_displays=False,
                   look_info=None,
+                  custom_output_info=None,
                   custom_lut_dir=None):
     """
     Create the *OCIO* config based on the configuration data
@@ -564,6 +661,9 @@ def create_config(config_data,
     if look_info is None:
         look_info = []
 
+    if custom_output_info is None:
+        custom_output_info = []
+
     prefixed_names = {}
     alias_colorspaces = []
 
@@ -579,7 +679,7 @@ def create_config(config_data,
     reference_data = config_data['referenceColorSpace']
 
     # Adding the colorspace *Family* into the name which helps with
-    # applications that presenting colorspaces as one a flat list.
+    # applications that present colorspaces as one a flat list.
     if prefix:
         prefixed_name = colorspace_prefixed_name(reference_data)
         prefixed_names[reference_data.name] = prefixed_name
@@ -635,12 +735,26 @@ def create_config(config_data,
 
         print('')
 
+    if custom_output_info:
+        print('Adding custom output transforms')
+
+        for custom_output in custom_output_info:
+            add_custom_output(config,
+                              custom_output,
+                              custom_lut_dir,
+                              reference_data,
+                              config_data,
+                              alias_colorspaces,
+                              prefix)
+
+        print('')
+
     print('Adding regular colorspaces')
 
     for colorspace in sorted(config_data['colorSpaces'],
         cmp=lambda x,y: cmp(x.family.lower(), y.family.lower())):
         # Adding the colorspace *Family* into the name which helps with
-        # applications that presenting colorspaces as one a flat list.
+        # applications that present colorspaces as one a flat list.
         if prefix:
             prefixed_name = colorspace_prefixed_name(colorspace)
             prefixed_names[colorspace.name] = prefixed_name
@@ -1370,6 +1484,8 @@ def generate_config(aces_ctl_directory,
                     bake_secondary_luts=True,
                     multiple_displays=False,
                     look_info=None,
+                    custom_output_info=None,
+                    custom_role_info=None,
                     copy_custom_luts=True,
                     cleanup=True,
                     prefix_colorspaces_with_family_names=True,
@@ -1395,6 +1511,10 @@ def generate_config(aces_ctl_directory,
         Output Transform or multiple displays, one for each Output Transform
     look_info : array of str or unicode, optional
         Paths and names for look data
+    custom_output_info : tuples of str or unicode, optional
+        Paths and names for custom output data
+    custom_role_info : list of tuples
+        Overrides for the default role assignments
     copy_custom_luts : bool, optional
         Whether to reference custom look LUTs directly or to copy them into a 
         directory within the generated configuration
@@ -1415,6 +1535,12 @@ def generate_config(aces_ctl_directory,
 
     if look_info is None:
         look_info = []
+
+    if custom_output_info is None:
+        custom_output_info = []
+
+    if custom_role_info is None:
+        custom_role_info = []
 
     custom_lut_dir = None
     if copy_custom_luts:
@@ -1440,12 +1566,42 @@ def generate_config(aces_ctl_directory,
                                      lut_resolution_3d,
                                      cleanup)
 
+    if custom_output_info:
+        print( "\n" )
+
+        for custom_output in custom_output_info:
+            (custom_output_name, custom_output_working_colorspace_name, 
+                custom_output_lut, custom_output_cccid) = unpack_default(custom_output, 4)
+            
+            print( "Adding %s to the odt_info struct" % custom_output_name )
+
+            odt_values = {}
+            odt_values['transformUserName'] = custom_output_name
+            odt_values['transformUserNamePrefix'] = "Output"
+            odt_values['transformHasFullLegalSwitch'] = False
+
+            odt_info['%s.ctl' % custom_output_name] = odt_values
+
+        print( "\n" )
+
+    if custom_role_info:
+        print( "\n" )
+
+        for custom_role_assignment in custom_role_info:
+            (role, colorspace_name) = custom_role_assignment
+            print( "Role overrride : %s - %s" % (role, colorspace_name))
+            config_data['roles'][role] = colorspace_name
+
+        print( "\n" )
+
+
     print('Creating config - with prefixes, with aliases')
     config = create_config(config_data,
                            prefix=prefix_colorspaces_with_family_names,
                            aliases=True,
                            multiple_displays=multiple_displays,
                            look_info=look_info,
+                           custom_output_info=custom_output_info,
                            custom_lut_dir=custom_lut_dir)
     print('\n\n\n')
 
@@ -1522,13 +1678,13 @@ def main():
     usage += ('\tcreate_aces_config -a /path/to/aces-dev/transforms/ctl '
               '--lutResolution1d 4096 --lutResolution3d 65 -c aces_1.0.1 '
               '\n\t\t--addACESLookLUT ACESLUTName '
-              '/path/to/SampleCDL.ccc cc03345')
+              '/path/to/lookLUT.3dl')
     usage += '\n'
     usage += 'Create a GUI-friendly ACES 1.0.1 config with a general LUT: \n'
     usage += ('\tcreate_aces_config -a /path/to/aces-dev/transforms/ctl '
               '--lutResolution1d 4096 --lutResolution3d 65 -c aces_1.0.1 '
               '\n\t\t--addCustomLookLUT CustomLUTName "ACES - ACEScc" '
-              '/path/to/SampleCDL.ccc cc03345')
+              '/path/to/lookLUT.3dl')
     usage += '\n'
     usage += ('\tIn this example, the LUT will be applied in the '
               'ACEScc colorspace, but the user could choose other spaces '
@@ -1540,12 +1696,24 @@ def main():
               '--lutResolution1d 4096 --lutResolution3d 65 -c aces_1.0.1 '
               '--shaper DolbyPQ')
     usage += '\n'
+    usage += 'Adding custom output transform'
+    usage += '\n'
+    usage += ('Create a GUI-friendly ACES 1.0.1 config with a custom output '
+              'transform: \n')
+    usage += ('\tcreate_aces_config -a /path/to/aces-dev/transforms/ctl '
+              '--lutResolution1d 4096 --lutResolution3d 65 -c aces_1.0.1 '
+              '\n\t\t--addCustomOutputLUT CustomOutputName '
+              '\"Input - ARRI - V3 LogC (EI800) - Wide Gamut\"'
+              '/path/to/outputLUT.3dl')
+    usage += '\n'
  
+    custom_output_info = []
+    custom_role_info = []
     look_info = []
 
     def look_info_callback(option, opt_str, value, parser):
-        print('look_info_callback')
-        print(option, opt_str, value, parser)
+        #print('look_info_callback')
+        #print(option, opt_str, value, parser)
         if opt_str == '--addCustomLookCDL':
             look_info.append(value)
         elif opt_str == '--addCustomLookLUT':
@@ -1554,6 +1722,18 @@ def main():
             look_info.append([value[0], 'ACES - ACEScc', value[1], value[2]])
         elif opt_str == '--addACESLookLUT':
             look_info.append([value[0], 'ACES - ACEScc', value[1]])
+
+    def output_info_callback(option, opt_str, value, parser):
+        #print('output_info_callback')
+        #print(option, opt_str, value, parser)
+        if opt_str == '--addCustomOutputLUT':
+            custom_output_info.append(value)
+
+    def role_info_callback(option, opt_str, value, parser):
+        #print('output_info_callback')
+        #print(option, opt_str, value, parser)
+        if opt_str == '--addCustomRole':
+            custom_role_info.append(value)
 
     p = optparse.OptionParser(description='',
                               prog='create_aces_config',
@@ -1581,6 +1761,12 @@ def main():
                  action='callback', callback=look_info_callback)
     p.add_option('--copyCustomLUTs', action='store_true', default=False)
 
+    p.add_option('--addCustomOutputLUT', '', type='string', nargs=3,
+                 action='callback', callback=output_info_callback)
+
+    p.add_option('--addCustomRole', '', type='string', nargs=2,
+                 action='callback', callback=role_info_callback)
+
     p.add_option('--shaper', '-s', default='Log2')
 
     options, arguments = p.parse_args()
@@ -1596,9 +1782,21 @@ def main():
     shaper_base_name = options.shaper
     prefix = True
 
-    print(look_info)
-
     print('command line : \n%s\n' % ' '.join(sys.argv))
+
+    if look_info:
+        print( "custom look info" )
+        for look in look_info:
+            print(look)
+
+    print( "\n" )
+
+    if custom_output_info:
+        print( "custom output info" )
+        for custom_output in custom_output_info:
+            print(custom_output)
+
+    print( "\n" )
 
     assert aces_ctl_directory is not None, (
         'process: No "{0}" environment variable defined or no "ACES CTL" '
@@ -1617,6 +1815,8 @@ def main():
                            bake_secondary_luts,
                            multiple_displays,
                            look_info,
+                           custom_output_info,
+                           custom_role_info,
                            copy_custom_luts,
                            cleanup_temp_images,
                            prefix,


### PR DESCRIPTION
…hat allow the addition of custom output transforms and role assignments.

Note that the colorspace specified using --addCustomOutputLUT is the prefixed version, like "Input - ARRI - V3 LogC (EI800) - Wide Gamut" whereas the colorspace specified using --addCustomRole is the non-prefixed version, like "V3 LogC (EI800) - Wide Gamut" or "sRGB - Texture".

More than one custom output LUT and more than one custome role assignment can be specified.

Example command line:
create_aces_config -a /path/to/aces-dev/transforms/ctl -c aces_1.0.2 --lutResolution1d 1024 --lutResolution3d 33 --addCustomOutputLUT "Project sRGB" "Input - ARRI - V3 LogC (EI800) - Wide Gamut" /path/to/project.3dl --addCustomRole compositing_log "V3 LogC (EI800) - Wide Gamut" --addCustomRole matte_paint "sRGB - Texture" --addCustomRole texture_paint  "sRGB - Texture"
